### PR TITLE
Add type_as(z) casts; try to prevent O1 amp error

### DIFF
--- a/activation_functions.py
+++ b/activation_functions.py
@@ -240,17 +240,17 @@ _ln2 = 0.6931471805599453
 def logistic_and_approx(z):
     return torch.where(
         (z < 0).all(dim=2),
-        z.sum(dim=2),
-        torch.min(z, dim=2).values,
-    )
+        z.sum(dim=2).type_as(z),
+        torch.min(z, dim=2).values.type_as(z),
+    ).type_as(z)
 
 
 def logistic_or_approx(z):
     return torch.where(
         (z > 0).all(dim=2),
-        z.sum(dim=2),
-        torch.max(z, dim=2).values,
-    )
+        z.sum(dim=2).type_as(z),
+        torch.max(z, dim=2).values.type_as(z),
+    ).type_as(z)
 
 
 def logistic_xnor_approx(z):


### PR DESCRIPTION
When training the model with opt level O1 amp, we are getting the error:

  File "pytorch-image-models/activation_functions.py", line 252, in logistic_or_approx
    torch.max(z, dim=2).values,
RuntimeError: expected scalar type float but found c10::Half

Try to alleviate this by casting everything to the same dtype as the input.