### PR TITLE
Increase GPUs to 8 and reduce batch size to prevent memory overflow

### DIFF
--- a/sbatch_effnet_train.sh
+++ b/sbatch_effnet_train.sh
@@ -2,9 +2,9 @@
 #SBATCH -p t4v2
 #SBATCH --exclude=gpu102
 #SBATCH --exclude=gpu115
-#SBATCH --gres=gpu:4                        # request GPU(s)
+#SBATCH --gres=gpu:8                        # request GPU(s)
 #SBATCH --qos=normal
-#SBATCH -c 24                                # number of CPU cores
+#SBATCH -c 32                                # number of CPU cores
 #SBATCH --mem=128G                           # memory per node
 #SBATCH --time=500:00:00                     # max walltime, hh:mm:ss
 #SBATCH --array=0%1                    # array value
@@ -44,5 +44,5 @@ echo ""
 echo "SAVE_PATH=$SAVE_PATH"
 echo "SEED=$SEED"
 
-./distributed_train.sh 4 $IMGNET_PATH --model efficientnet_b0 -b 192 --actfun $ACTFUN --output $SAVE_PATH --check-path $CHECK_PATH --sched step --epochs 450 --decay-epochs 2.4 --decay-rate .97 --opt rmsproptf --opt-eps .001 -j 8 --warmup-lr 1e-6 --weight-decay 1e-5 --drop 0.2 --drop-connect 0.2 --model-ema --model-ema-decay 0.9999 --aa original --remode pixel --reprob 0.2 --lr .048 --control-amp $AMP
+./distributed_train.sh 8 $IMGNET_PATH --model efficientnet_b0 -b 64 --actfun $ACTFUN --output $SAVE_PATH --check-path $CHECK_PATH --sched step --epochs 450 --decay-epochs 2.4 --decay-rate .97 --opt rmsproptf --opt-eps .001 -j 4 --warmup-lr 1e-6 --weight-decay 1e-5 --drop 0.2 --drop-connect 0.2 --model-ema --model-ema-decay 0.9999 --aa original --remode pixel --reprob 0.2 --lr .032 --control-amp $AMP
 


### PR DESCRIPTION
- Increase number of CPU cores requested to be amount on one node
- Reduce number of workers per process to be number of requested nodes divided by number of GPUs per node
- Increase number of GPUs to 8
- Getting memory overflow errors when using actfun pairs, so had to reduce batch size per GPU substantially
- Set LR to reflect new number of GPUs and batch size per GPU